### PR TITLE
Fix parameter name in search agent

### DIFF
--- a/langchain-projects/search_engine_with_tools_and_agents/app.py
+++ b/langchain-projects/search_engine_with_tools_and_agents/app.py
@@ -70,7 +70,7 @@ if prompt:= st.chat_input(
         tools=tools,
         llm=llm,
         agent=AgentType.CHAT_ZERO_SHOT_REACT_DESCRIPTION,
-        handling_parsing_errors = True
+        handle_parsing_errors=True
     )
     
     with st.chat_message("assistant"):


### PR DESCRIPTION
## Summary
- fix typo in `initialize_agent` call to use `handle_parsing_errors`

## Testing
- `python -m py_compile langchain-projects/search_engine_with_tools_and_agents/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848123a76e08332aa4937664df29e01