### PR TITLE
Fix system prompt wording

### DIFF
--- a/langchain-projects/qna_chatbot_ollama/app.py
+++ b/langchain-projects/qna_chatbot_ollama/app.py
@@ -22,7 +22,7 @@ prompt = ChatPromptTemplate.from_messages(
     [
         (
             "system",
-            "You are a helpful assistant that helps people resolve queries. Please response to the user queries. Please do not answer anything else. Only answer the user"
+            "You are a helpful assistant that helps people resolve queries. Please respond to the user queries. Please do not answer anything else. Only answer the user"
         ),
         (
             "user",

--- a/langchain-projects/qna_chatbot_openai/app.py
+++ b/langchain-projects/qna_chatbot_openai/app.py
@@ -22,7 +22,7 @@ os.environ["LANGSMITH_TRACING"] = os.getenv("LANGSMITH_TRACING")
 prompt = ChatPromptTemplate(
     [
         (
-            "system", "You are a helpful assistant that helps people resolve queries. Please response to the user queries. Please do not answer anything else. Only answer the user"
+            "system", "You are a helpful assistant that helps people resolve queries. Please respond to the user queries. Please do not answer anything else. Only answer the user"
         ),
         (
             "user",


### PR DESCRIPTION
## Summary
- fix typos in system prompts for OpenAI and Ollama chatbots

## Testing
- `python -m py_compile langchain-projects/qna_chatbot_ollama/app.py langchain-projects/qna_chatbot_openai/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684812bc35c883329691bd159fd54906